### PR TITLE
:sparkles: elasticSearch 데이터 삽입 시 id 설정 (#1)

### DIFF
--- a/.idea/dbnavigator.xml
+++ b/.idea/dbnavigator.xml
@@ -2,7 +2,7 @@
 <project version="4">
   <component name="DBNavigator.Project.DataEditorManager">
     <record-view-column-sorting-type value="BY_INDEX" />
-    <value-preview-text-wrapping value="true" />
+    <value-preview-text-wrapping value="false" />
     <value-preview-pinned value="false" />
   </component>
   <component name="DBNavigator.Project.DataExportManager">

--- a/.idea/inspectionProfiles/Project_Default.xml
+++ b/.idea/inspectionProfiles/Project_Default.xml
@@ -4,8 +4,16 @@
     <inspection_tool class="PyPep8Inspection" enabled="true" level="WEAK WARNING" enabled_by_default="true">
       <option name="ignoredErrors">
         <list>
-          <option value="E501" />
-          <option value="E722" />
+          <option value="W605" />
+          <option value="E231" />
+          <option value="W292" />
+        </list>
+      </option>
+    </inspection_tool>
+    <inspection_tool class="PyPep8NamingInspection" enabled="true" level="WEAK WARNING" enabled_by_default="true">
+      <option name="ignoredErrors">
+        <list>
+          <option value="N802" />
         </list>
       </option>
     </inspection_tool>

--- a/crawler/kakao.py
+++ b/crawler/kakao.py
@@ -6,7 +6,10 @@ import time
 import json
 from campaign import *
 
+
 _URL_DONATE_LIST = "https://together.kakao.com/fundraisings/now?sort=1"
+_SITE_NAME = "kakao"
+_CAMPAIGNS = "campaigns"
 
 
 def set_chrome_driver():
@@ -59,7 +62,7 @@ def get_theme():
 
 
 def get_body():
-    return driver.page_source
+    return driver.find_element(By.TAG_NAME, "fundraising-content").text.replace('\n',' ')
 
 
 def get_organization_name():
@@ -86,6 +89,15 @@ def get_prices():
 
 def get_percent():
     return driver.find_element(By.CLASS_NAME, "txt_result").text
+
+
+def set_campaign_data_with_index(campaign):
+    index = dict()
+    index["_index"] = _CAMPAIGNS
+    index["_type"] = _SITE_NAME
+    index["_id"] = campaign.campaign_id
+    index["_source"] = campaign.__dict__     # 딕셔너리 형태로 저장
+    return index
 
 
 def crawling_each_campaign():
@@ -118,8 +130,12 @@ def crawling_each_campaign():
         target_price,
         status_price,
         percent)
-    data.append(campaign.__dict__)  # 딕셔너리 형태로 저장
 
+    campaign_data = set_campaign_data_with_index(campaign)
+
+    data.append(campaign_data)
+
+    # print(data)
 
 if __name__ == '__main__':
 
@@ -162,5 +178,5 @@ if __name__ == '__main__':
     print("... 카카오같이가치 크롤링 끝 ...")
 
     # json 으로 저장
-    with open('..\data\kakao.json', 'w', encoding='utf-8') as f:
+    with open('.\data\kakao.json', 'w', encoding='utf-8') as f:
         json.dump(data, f, ensure_ascii=False, indent=4)

--- a/elasticSearch/elasticSearch_crud.py
+++ b/elasticSearch/elasticSearch_crud.py
@@ -1,14 +1,16 @@
-from elasticsearch import helpers,Elasticsearch
+from elasticsearch import helpers, Elasticsearch
 import json
 
 sites = ['happybean', 'kakao']
-    
+
+
 def insertData():
     for site in sites:
-        with open(f'data\{site}.json', 'r', encoding = 'utf-8') as f:
+        with open(f'data\{site}.json', 'r', encoding='utf-8') as f:
             data = json.loads(f.read())
-        res = helpers.bulk(es, data, index="campaigns", doc_type=site)
-    
+        res = helpers.bulk(es, data)
+
+
 if __name__ == '__main__':
     es = Elasticsearch('http://localhost:9200/')
     insertData()


### PR DESCRIPTION
- elasticSearch 데이터 삽입 시 _index,_type,_id,_source를 직접 정의하는 것으로 코드를 바꿈
- 본문 크롤링 방식을 기존(태그까지 긁어옴)에서 텍스트만 긁어오도록 수정 
- json 파일 저장 디렉터리 구조 수정 